### PR TITLE
Add forward_query_string for custom behaviours.

### DIFF
--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -186,16 +186,17 @@ resource "aws_cloudfront_distribution" "website_cdn" {
 
   dynamic "ordered_cache_behavior" {
     for_each = [for b in var.ordered_cache_behaviors : {
-      min_ttl          = b.min_ttl
-      default_ttl      = b.default_ttl
-      max_ttl          = b.max_ttl
-      path_pattern     = b.path_pattern
-      target_origin_id = b.target_origin_id
-      headers          = b.forwarded_values_headers
-      forward          = b.cookies_forward
-      event_type       = b.event_type
-      lambda_arn       = b.lambda_arn
-      include_body     = b.include_body
+      min_ttl              = b.min_ttl
+      default_ttl          = b.default_ttl
+      max_ttl              = b.max_ttl
+      path_pattern         = b.path_pattern
+      target_origin_id     = b.target_origin_id
+      headers              = b.forwarded_values_headers
+      forward              = b.cookies_forward
+      event_type           = b.event_type
+      lambda_arn           = b.lambda_arn
+      include_body         = b.include_body
+      forward_query_string = b.forward_query_string
     }]
     content {
       allowed_methods = ["GET", "HEAD", "DELETE", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -210,7 +211,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
       viewer_protocol_policy = "redirect-to-https"
 
       forwarded_values {
-        query_string = false
+        query_string = ordered_cache_behavior.value.forward_query_string
         headers      = ordered_cache_behavior.value.headers
         cookies {
           forward = ordered_cache_behavior.value.forward

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -103,6 +103,7 @@ variable "ordered_cache_behaviors" {
     event_type               = string
     lambda_arn               = string
     include_body             = bool
+    forward_query_string     = bool
   }))
 }
 


### PR DESCRIPTION
At the moment it's possible to configure query string forwarding for the Default behaviour only (with `forward-query-string` variable). 

This change will allow configuring it for behaviours with precedence above Default too.