### PR TITLE
Custom User-Agent header is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
   distribution and the source S3 bucket, or using custom headers between the distribution and the bucket.
   The use of an Origin Access User prescribes accessing the source bucket in REST mode which results in
   bucket redirects not being followed. As a result, this module will use the custom header option.
+
+  If this parameter is the empty string, a custom User-Agent header will not be added.
 * `deployer`: the name of an existing IAM user that will be used to push contents to the S3 bucket. This
   user will get a role policy attached to it, configured to have read/write access to the bucket that
   will be created.

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -192,9 +192,13 @@ resource "aws_cloudfront_distribution" "website_cdn" {
         origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
       }
 
-      custom_header {
-        name  = "User-Agent"
-        value = origin.value.duplicate_content_penalty_secret
+      dynamic "custom_header" {
+        for_each = origin.value.duplicate_content_penalty_secret != "" ? ["present"] : []
+
+        content {
+          name  = "User-Agent"
+          value = origin.value.duplicate_content_penalty_secret
+        }
       }
     }
   }


### PR DESCRIPTION
If the parameter is the empty string, omit the custom User-Agent
header.

We only need this for S3 origins, not for services such as querytool,
for which it might be useful to see the original User-Agent header.