### PR TITLE
Add PutObjectTagging permissions to the bucket role

### DIFF
--- a/site-main/website_bucket_policy.json
+++ b/site-main/website_bucket_policy.json
@@ -22,7 +22,7 @@
       "Principal": {
         "AWS": "${ci_role_arn}"
       },
-      "Action": "s3:PutObject",
+      "Action": ["s3:PutObject", "s3:PutObjectTagging"],
       "Resource": "arn:aws:s3:::${bucket}/*"
     }
   ]


### PR DESCRIPTION
Add PutObjectTagging permissions to the bucket role

On CI build we are copying frontend website from one s3 bucket to another. And apparently on s3 copy it happens slightly differently (the problem is described [here](https://medium.com/collaborne-engineering/s3-copyobject-access-denied-5f7a6fe0393e) and one needs additional permissions.