### PR TITLE
Removes additional CI related permissions

### DIFF
--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -34,7 +34,6 @@ data "template_file" "bucket_policy" {
   vars = {
     bucket = var.bucket_name
     secret = var.duplicate-content-penalty-secret
-    ci_role_arn = var.ci_role_arn
   }
 }
 

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -17,11 +17,6 @@ variable "bucket_path" {
   default     = "/"
 }
 
-variable "ci_role_arn" {
-  type        = string
-  description = "An ARN of the CI role which has permissions to upload artifacts to this bucket"
-}
-
 variable "duplicate-content-penalty-secret" {
   type = string
 }

--- a/site-main/website_bucket_policy.json
+++ b/site-main/website_bucket_policy.json
@@ -16,14 +16,6 @@
           "aws:UserAgent": "${secret}"
         }
       }
-    },
-	{
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${ci_role_arn}"
-      },
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::${bucket}/*"
     }
   ]
 }

--- a/site-main/website_bucket_policy.json
+++ b/site-main/website_bucket_policy.json
@@ -22,7 +22,7 @@
       "Principal": {
         "AWS": "${ci_role_arn}"
       },
-      "Action": ["s3:PutObject", "s3:PutObjectTagging"],
+      "Action": "s3:PutObject",
       "Resource": "arn:aws:s3:::${bucket}/*"
     }
   ]


### PR DESCRIPTION
Removes additional CI related permissions.
These permissions were necessary for the CI to upload artifacts to the S3 bucket. The other more clean way was found by using specific CI role.