### PR TITLE
Support configuring a WAF web ACL

### DIFF
--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -253,4 +253,6 @@ resource "aws_cloudfront_distribution" "website_cdn" {
       }
     }
   }
+
+  web_acl_id = var.web_acl_id
 }

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -146,3 +146,9 @@ variable "error_document" {
   description = "An absolute path to the document to return in case of a 4XX error."
   default     = "404.html"
 }
+
+variable "web_acl_id" {
+  type        = string
+  description = "An AWS WAF web ACL to use with the Cloudfront distribution"
+  default     = null
+}


### PR DESCRIPTION
This makes it possible to use WAF to block certain requests to the
Cloudfront distribution.