### PR TITLE
Add option for creating AAAA record in r53-alias module

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ root domain.
   usually pass the `website_cdn_hostname` output variable from the main or redirect site here.
 * `cdn_hosted_zone_id`: the Hosted Zone ID of the CloudFront distribution. You usually pass the
   `website_cdn_zone_id` output variable from the main or redirect site here.
-* `route53_zone_id`: the Route53 Zone ID where the CNAME entry must be created.
+* `route53_zone_id`: the Route53 Zone ID where the alias entry must be created.
+* `ipv6`:  (Optional) Add AAAA record as well as A for the alias. Default value = `false`
 
 ## Users
 

--- a/r53-alias/main.tf
+++ b/r53-alias/main.tf
@@ -13,3 +13,16 @@ resource "aws_route53_record" "cdn-alias" {
   }
 }
 
+resource "aws_route53_record" "cdn-alias-aaaa" {
+  count = var.ipv6 ? 1 : 0
+
+  zone_id = var.route53_zone_id
+  name    = var.domain
+  type    = "AAAA"
+
+  alias {
+    name                   = var.target
+    zone_id                = var.cdn_hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/r53-alias/variables.tf
+++ b/r53-alias/variables.tf
@@ -13,3 +13,9 @@ variable "route53_zone_id" {
 variable "cdn_hosted_zone_id" {
   type = string
 }
+
+variable "ipv6" {
+  type        = bool
+  description = "Add AAAA alias record for IPv6 access to CloudFront distribution"
+  default     = false
+}


### PR DESCRIPTION
The site-main and site-redirect modules already support IPv6 (and r53-cname doesn't need to do anything special), so let's add the missing piece of the puzzle.