### PR TITLE
Fix response_headers_policy_id not being propagated

### DIFF
--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -130,6 +130,8 @@ variable "ordered_cache_behaviors" {
     lambda_arn               = string
     include_body             = bool
     forward_query_string     = bool
+
+    response_headers_policy_id = string
   }))
 }
 


### PR DESCRIPTION
Without this even if `response_headers_policy_id` is provided, it is ignored by terraform