### PR TITLE
Add HTTPS alias record

### DIFF
--- a/r53-alias/main.tf
+++ b/r53-alias/main.tf
@@ -26,3 +26,15 @@ resource "aws_route53_record" "cdn-alias-aaaa" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "cdn-alias-https" {
+  zone_id = var.route53_zone_id
+  name    = var.domain
+  type    = "HTTPS"
+
+  alias {
+    name                   = var.target
+    zone_id                = var.cdn_hosted_zone_id
+    evaluate_target_health = false
+  }
+}


### PR DESCRIPTION
Now supported by Cloudfront:
https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-cloudfront-https-dns-records/